### PR TITLE
Fixes #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "url": "git+https://github.com/jskuby/react-native-gridview.git"
   },
   "author": "Jason Skuby",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "prop-types": "^15.5.7"
+  }
 }

--- a/src/GridView.js
+++ b/src/GridView.js
@@ -1,13 +1,6 @@
-import React, {
-  Component,
-  PropTypes,
-} from 'react';
-import {
-  Dimensions,
-  ListView,
-  StyleSheet,
-  View,
-} from 'react-native';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Dimensions, ListView, StyleSheet, View } from 'react-native';
 
 class GridView extends Component {
   constructor(props) {


### PR DESCRIPTION
Pull in the prop-types package and reference its default export, instead of referencing PropTypes from react